### PR TITLE
A few minor Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM rust:1.64-slim-buster
+FROM rust:1.69-slim-buster
 
 WORKDIR /usr/src/rusthound
 
-RUN apt-get -y update && apt-get -y install gcc libclang-dev clang libclang-dev libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit musl-tools make gcc-mingw-w64-x86-64
+RUN \
+	apt-get -y update && \
+	apt-get -y install gcc clang libclang-dev libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit musl-tools make gcc-mingw-w64-x86-64 && \
+	rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["make"]

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ usage: make install_macos_deps
 Use RustHound with Docker to make sure to have all dependencies.
 
 ```bash
-docker build -t rusthound .
+docker build --rm -t rusthound .
 
 # Then
-docker run -v ./:/usr/src/rusthound -it rusthound windows
-docker run -v ./:/usr/src/rusthound -it rusthound linux_musl
-docker run -v ./:/usr/src/rusthound -it rusthound macos
+docker run --rm -v ./:/usr/src/rusthound rusthound windows
+docker run --rm -v ./:/usr/src/rusthound rusthound linux_musl
+docker run --rm -v ./:/usr/src/rusthound rusthound macos
 ```
 
 ## Using Cargo
@@ -109,7 +109,7 @@ RustHound supports Kerberos and GSSAPI. Therefore, it requires Clang and its dev
 For example:
 ```bash
 # Debian/Ubuntu
-sudo apt-get -y update && sudo apt-get -y install gcc libclang-dev clang libclang-dev libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit musl-tools gcc-mingw-w64-x86-64
+sudo apt-get -y update && sudo apt-get -y install gcc clang libclang-dev libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit musl-tools gcc-mingw-w64-x86-64
 ```
 
 Here is how to compile the "release" and "debug" versions using the **cargo** command.


### PR DESCRIPTION
1/ The Dockerfile and the README files were mentioning the duplicate dependency libclang-dev.

2/ The Dockerfile is reorganized with line breaks for clarity

3a/ The argument --rm is added to Docker commands to clean up containers after execution.
3b/ The argument -it is removed as the build procedure is not interactive (IMO, at least when building for Linux)

4/ The version of rust is bumped from 1.64 to 1.69