### PR TITLE
Fix for Flag AccountDisabled.

### DIFF
--- a/src/json/parser/bh_41.rs
+++ b/src/json/parser/bh_41.rs
@@ -127,7 +127,7 @@ pub fn parse_user(
                 //trace!("UAC : {:?}",uac_flags);
                 for flag in uac_flags {
                     if flag.contains("AccountDisable") {
-                        user_json["Properties"]["enabled"] = true.into();
+                        user_json["Properties"]["enabled"] = false.into();
                     };
                     //if flag.contains("Lockout") { let enabled = true; user_json["Properties"]["enabled"] = enabled.into(); };
                     if flag.contains("PasswordNotRequired") {


### PR DESCRIPTION
Accounts are always set as enabled in the current RustHound version. The fix is setting the json value `user_json["Properties"]["enabled"]` to false if the UAC flag contains `AccountDisabled` . After the change I did a quick check in a test environment to verify the change. Maybe it would be a good idea to verify the other UAC flags - I added it to my todo list if no one else already did that?